### PR TITLE
Upgrade to Spark 3.2.0

### DIFF
--- a/.azuredevops/build-and-test.yml
+++ b/.azuredevops/build-and-test.yml
@@ -4,20 +4,41 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 trigger:
-- master
+  - master
 
-pool:
-  vmImage: ubuntu-latest
+stages:
+  - stage: BuildAndTest
+    jobs:
+      - job: BuildAndTestWithDocker
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: DockerCompose@0
+            displayName: Docker compose up
+            inputs:
+              action: Run a Docker Compose command
+              dockerComposeFile: docker-compose.yml
+              projectName: sql-spark-connector
+              qualifyImageNames: true
+              dockerComposeCommand: up -d
 
-steps:
-- task: Maven@3
-  displayName: Maven Build and Test
-  inputs:
-    mavenPomFile: 'pom.xml'
-    mavenOptions: '-Xmx3072m'
-    javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.8'
-    jdkArchitectureOption: 'x64'
-    publishJUnitResults: true
-    testResultsFiles: '**/surefire-reports/TEST-*.xml'
-    goals: 'test'
+          - task: Maven@3
+            displayName: Maven build and test
+            inputs:
+              mavenPomFile: 'pom.xml'
+              mavenOptions: '-Xmx3072m'
+              javaHomeOption: 'JDKVersion'
+              jdkVersionOption: '1.8'
+              jdkArchitectureOption: 'x64'
+              publishJUnitResults: true
+              testResultsFiles: '**/surefire-reports/TEST-*.xml'
+              goals: 'test'
+
+          - task: DockerCompose@0
+            displayName: Docker compose down
+            inputs:
+              action: Run a Docker Compose command
+              dockerComposeFile: docker-compose.yml
+              projectName: sql-spark-connector
+              qualifyImageNames: true
+              dockerComposeCommand: down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+
+services:
+  sql-server:
+    image: "mcr.microsoft.com/mssql/server:2019-latest"
+    environment:
+      SA_PASSWORD: 'secure_password_123'
+      ACCEPT_EULA: 'Y'
+      MSSQL_PID: 'Standard'
+    ports:
+      - '1433:1433'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.solytic</groupId>
     <artifactId>spark-mssql-connector</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The Apache Spark Connector for SQL Server and Azure SQL is a high-performance connector that enables you to use transactional data in big data analytics and persists results for ad-hoc queries or reporting.</description>
     <url>https://github.com/microsoft/sql-spark-connector</url>
@@ -216,7 +216,7 @@
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>2.12.11</scala.version>
-                <spark.version>3.1.2</spark.version>
+                <spark.version>3.2.0</spark.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/src/test/scala/com/microsoft/sqlserver/jdbc/spark/integration/SqlServerReadWriteTests.scala
+++ b/src/test/scala/com/microsoft/sqlserver/jdbc/spark/integration/SqlServerReadWriteTests.scala
@@ -1,0 +1,83 @@
+package com.microsoft.sqlserver.jdbc.spark.integration
+
+import com.microsoft.sqlserver.jdbc.spark.SQLServerBulkJdbcOptions
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
+import org.apache.spark.sql.{SaveMode, SparkSession}
+
+import java.util.UUID
+
+/**
+ * This test class provides an integration test that checks whether the connector can write to and read from SQL server.
+ *
+ * This test class needs the SQL Server instance from the docker-compose setup.
+ * Run `docker compose up` in the root directory of the project for this test to succeed.
+ */
+class SqlServerReadWriteTests extends SparkFunSuite {
+  private val url = "jdbc:sqlserver://localhost:1433;user=sa;password=secure_password_123;"
+  private val dbTable = "model.DataTable"
+
+  private lazy val spark = getSparkSession
+
+  test("Spark should be able to write to and read from SQL server using the connector") {
+    import spark.implicits._
+
+    // create the database and tables for testing
+    val dbName = ensureTestSetup()
+
+    // setup the input data
+    val inputData = Seq(
+      (1, "one"),
+      (2, "two")
+    )
+    val dataToWrite = inputData.toDF("id", "text")
+
+    // write
+    dataToWrite.write
+      .format("com.microsoft.sqlserver.jdbc.spark")
+      .options(Map("url" -> s"$url;database=$dbName", "dbtable" -> dbTable))
+      .option("dbtable", dbTable)
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    // read
+    val outputData = spark.read
+      .format("com.microsoft.sqlserver.jdbc.spark")
+      .options(Map("url" -> s"$url;database=$dbName", "query" -> s"SELECT * FROM $dbTable"))
+      .load()
+      .orderBy("id")
+      .as[(Int, String)]
+      .collect()
+
+    // assert that the input and output data is the same
+    assertResult(inputData)(outputData)
+  }
+
+  private def getSparkSession: SparkSession = {
+    val spark = SparkSession.builder()
+      .master("local[*]")
+      .getOrCreate()
+
+    spark
+  }
+
+  private def ensureTestSetup(): String = {
+    val dbName = s"testing_${UUID.randomUUID().toString.replace("-", "_")}"
+
+    val jdbcOptions = new SQLServerBulkJdbcOptions(Map("url" -> url, "dbtable" -> dbTable))
+
+    val jdbcConnection = JdbcUtils.createConnectionFactory(jdbcOptions)()
+    val statement = jdbcConnection.createStatement()
+
+    statement.executeUpdate(s"CREATE DATABASE $dbName")
+    statement.executeUpdate(s"USE $dbName")
+    statement.executeUpdate("CREATE SCHEMA model")
+    statement.executeUpdate("CREATE TABLE model.DataTable (id INT NOT NULL, text NVARCHAR NOT NULL)")
+    statement.executeUpdate("DELETE FROM model.DataTable")
+
+    statement.closeOnCompletion()
+    jdbcConnection.close()
+
+    dbName
+  }
+}


### PR DESCRIPTION
- Ported integration tests from #1 to write data to and read data from a SQL server
- Ported the docker compose setup from #1 to spin up a local instance of SQL server
- Ported the pipeline changes from #1 to run the docker compose setup during the tests
- Bumped the version of the library to 1.3.0

Fixes microsoft#164